### PR TITLE
Create pull_request_template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,16 @@
+## Describe your changes
+
+## Validation & Testing
+
+## Checklist before requesting a review
+- [ ] I have performed a self-review of my code
+- [ ] My code follows style guidelines
+- [ ] I have commented my code as necessary
+- [ ] I have made corresponding changes to documentation
+- [ ] My code runs without errors
+- [ ] I have implemented primary key tests
+- [ ] Every model has a corresponding yml file
+- [ ] I have generated the DAG locally with dbt and updated the files in the `docs/` path
+
+## Gif of how this PR makes you feel
+![](url)


### PR DESCRIPTION
Proposal for pull_request_template. I added two things to the template I've seen used on other repos. 

- Added a new checklist item for making sure the DAG files have been updated in the `docs/` path
- I also added a gif section. That's one of my favorite things to see in people's PRs. I'm totally open to removing it if people don't like it.😃 